### PR TITLE
Add NOT_FOUND to default retry

### DIFF
--- a/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/GrpcLookupFunction.java
+++ b/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/GrpcLookupFunction.java
@@ -58,7 +58,8 @@ public class GrpcLookupFunction extends AsyncLookupFunction {
                 "retryableStatusCodes": [
                   "UNAVAILABLE",
                   "INTERNAL",
-                  "PERMISSION_DENIED"
+                  "PERMISSION_DENIED",
+                  "NOT_FOUND"
                 ]
               }
             }


### PR DESCRIPTION
When a GRPC error is returned the flink job will terminate. Adding NOT_FOUND to the list of retryables to avoid immediate termination.