### PR TITLE
Support mock GRPC error responses

### DIFF
--- a/example/src/main/resources/grpc_mock_config/mock_grpc_service.pkl
+++ b/example/src/main/resources/grpc_mock_config/mock_grpc_service.pkl
@@ -5,7 +5,7 @@ services {
     name = "SayHello"
     methodDescriptorSource = "io.grpc.examples.helloworld.GreeterGrpc#getSayHelloMethod"
     requests = new {
-      new JsonataRequest {
+      new JsonataResponse {
         requestExpression = "true"
         responseExpression = """
           {

--- a/mock-rpc-server/src/main/resources/MockServer.pkl
+++ b/mock-rpc-server/src/main/resources/MockServer.pkl
@@ -22,12 +22,21 @@ class Service {
 abstract class MockRequest {
 }
 
-class JsonataRequest extends MockRequest {
+abstract class JsonataRequest extends MockRequest {
   /// A JSONata query which is ran against the GRPC request object as JSON.
   /// Expected for the expression to be a predicate.
   requestExpression: String
+}
 
+class JsonataResponse extends JsonataRequest {
   /// A JSONata query which is ran against the GRPC request object as JSON.
   /// Expected for the expression to result in a JSON object which is mapped to the GRPC response.
   responseExpression: String
+}
+
+class JsonataErrorResponse extends JsonataRequest {
+
+  responseStatusCode: Int32(isBetween(1, 16))
+
+  responseMessage: String
 }

--- a/mock-rpc-server/src/test/java/io/mock/grpc/MockJsonRpcServerTest.java
+++ b/mock-rpc-server/src/test/java/io/mock/grpc/MockJsonRpcServerTest.java
@@ -66,6 +66,36 @@ class MockJsonRpcServerTest {
   }
 
   @Test
+  @DisplayName("Error Response returns status exception")
+  void test_error_response() throws IOException {
+    final var config =
+        """
+      amends "modulepath:/test_config.pkl"
+
+      services {
+        [[name == "SayHello"]]
+        {
+          requests = new {
+            new JsonataErrorResponse {
+              requestExpression = "true"
+              responseStatusCode = 3
+              responseMessage = "unexpected request shape"
+            }
+          }
+        }
+      }
+    """;
+
+    final var client = GreeterGrpc.newBlockingStub(startServer(ModuleSource.text(config)));
+    var e =
+        Assertions.assertThrows(
+            StatusRuntimeException.class,
+            () -> client.sayHello(HelloRequest.newBuilder().setName("Name not found").build()));
+    Truth.assertThat(e.getStatus().getCode()).isEqualTo(Status.INVALID_ARGUMENT.getCode());
+    Truth.assertThat(e.getMessage()).isEqualTo("INVALID_ARGUMENT: unexpected request shape");
+  }
+
+  @Test
   @DisplayName("Can return static response")
   void test_static_response() throws IOException {
     final var config =
@@ -76,7 +106,7 @@ class MockJsonRpcServerTest {
         [[name == "SayHello"]]
         {
           requests = new {
-            new JsonataRequest {
+            new JsonataResponse {
               requestExpression = "true"
               responseExpression = \"""
                 {
@@ -107,7 +137,7 @@ class MockJsonRpcServerTest {
         [[name == "SayHello"]]
         {
           requests = new {
-            new JsonataRequest {
+            new JsonataResponse {
               requestExpression = "true"
               responseExpression = \"""
                 {
@@ -135,7 +165,7 @@ class MockJsonRpcServerTest {
         [[name == "SayHello"]]
         {
           requests = new {
-            new JsonataRequest {
+            new JsonataResponse {
               requestExpression = "true"
               responseExpression = \"""
                 {
@@ -163,7 +193,7 @@ class MockJsonRpcServerTest {
         [[name == "SayHello"]]
         {
           requests = new {
-            new JsonataRequest {
+            new JsonataResponse {
               requestExpression = "name='John'"
               responseExpression = \"""
                 {
@@ -171,7 +201,7 @@ class MockJsonRpcServerTest {
                 }
               \"""
             }
-            new JsonataRequest {
+            new JsonataResponse {
               requestExpression = "true"
               responseExpression = \"""
                 {


### PR DESCRIPTION
Changing the GRPC pkl model to support mocking an error response.

Non-backwards compatible change.