### PR TITLE
Add deduplication for concurrent requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ The primary use case for the gRPC connector is to be used in a [Lookup Join](htt
 * Sink - Add Table Sink support to egress via gRPC
 * Auth - Currently assuming internal private networks
 * Cacheable error codes (configurable)
-* Wrapped request/response types
-* De-duplicate requests
 
 ## Example Usage
 

--- a/flink-connector-grpc/build.gradle.kts
+++ b/flink-connector-grpc/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation("com.google.code.gson:gson:2.11.0")
     implementation("com.google.auto.service:auto-service-annotations:1.1.1")
     implementation("org.apache.flink:flink-protobuf:$flinkVersion")
+    implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
 
     compileOnly("org.apache.flink:flink-table-api-java:$flinkVersion")
 

--- a/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/GrpcConnectorOptions.java
+++ b/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/GrpcConnectorOptions.java
@@ -84,7 +84,7 @@ public final class GrpcConnectorOptions {
           .asList()
           .defaultValues(1, 2, 4, 8, 10, 13, 14)
           .withDescription(
-              "List of GRPC status codes that should be treated as errors, separated by semicolon.");
+              "List of GRPC status codes that should be retried, separated by semicolon.");
   public static final ConfigOption<List<Integer>> GRPC_ERROR_CODES =
       ConfigOptions.key("grpc-error-codes")
           .intType()

--- a/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/service/DeduplicatingClient.java
+++ b/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/service/DeduplicatingClient.java
@@ -1,0 +1,92 @@
+//
+// Copyright 2024 Ian Stewart
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package org.apache.flink.connector.grpc.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.table.data.RowData;
+import org.checkerframework.checker.index.qual.NonNegative;
+
+class DeduplicatingClient implements GrpcServiceClient {
+
+  // TODO: Can this be loaded from `table.exec.async-lookup.timeout` or GRPC Deadlines??
+  private static final Duration EXPIRE_MAX = Duration.ofMinutes(10);
+  private static final Duration EXPIRE_AFTER_COMPLETE = Duration.ofSeconds(5);
+
+  private final GrpcServiceClient delegate;
+
+  private final Cache<RowData, CompletableFuture<RowData>> futureCache;
+
+  public DeduplicatingClient(GrpcServiceClient client) {
+    this.delegate = client;
+    this.futureCache =
+        Caffeine.newBuilder()
+            .expireAfter(new BoundedExpiry<RowData, CompletableFuture<RowData>>(EXPIRE_MAX))
+            .weakValues()
+            .build();
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.delegate.close();
+  }
+
+  @Override
+  public CompletableFuture<RowData> asyncCall(RowData req) {
+    return this.futureCache.get(
+        req,
+        key ->
+            this.delegate
+                .asyncCall(req)
+                .whenComplete( // Set the expiration after future is completed
+                    (val, err) ->
+                        this.futureCache
+                            .policy()
+                            .expireVariably()
+                            .get()
+                            .setExpiresAfter(req, EXPIRE_AFTER_COMPLETE)));
+  }
+
+  private static class BoundedExpiry<K, V> implements Expiry<K, V> {
+
+    private final long maxExpireNanos;
+
+    public BoundedExpiry(Duration maxExpire) {
+      this.maxExpireNanos = maxExpire.toNanos();
+    }
+
+    @Override
+    public long expireAfterCreate(K key, V value, long currentTime) {
+      return maxExpireNanos;
+    }
+
+    @Override
+    public long expireAfterUpdate(
+        K key, V value, long currentTime, @NonNegative long currentDuration) {
+      return currentDuration;
+    }
+
+    @Override
+    public long expireAfterRead(
+        K key, V value, long currentTime, @NonNegative long currentDuration) {
+      return currentDuration;
+    }
+  }
+}

--- a/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/service/GrpcServiceClient.java
+++ b/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/service/GrpcServiceClient.java
@@ -33,7 +33,10 @@ public interface GrpcServiceClient extends Closeable {
 
   static final SharedResourceHolder<SharedClientKey, GrpcServiceClient> SHARED_CLIENTS =
       new SharedResourceHolder<>(
-          key -> new GrpcServiceClientImpl(key.config(), key.requestSchema(), key.responseSchema()),
+          key ->
+              new DeduplicatingClient(
+                  new GrpcServiceClientImpl(
+                      key.config(), key.requestSchema(), key.responseSchema())),
           GrpcServiceClient.class);
 
   public static GrpcServiceClient createSharedClient(


### PR DESCRIPTION
Adding a cache for request futures. Evicting requests for cache after 5 seconds of request completion.