### PR TITLE
Using thread pools for async requests

### DIFF
--- a/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/AsyncGrpcLookupFunction.java
+++ b/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/AsyncGrpcLookupFunction.java
@@ -16,12 +16,18 @@
 package org.apache.flink.connector.grpc;
 
 import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.StatusRuntimeException;
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -32,6 +38,7 @@ import org.apache.flink.connector.grpc.service.GrpcServiceClient;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.AsyncLookupFunction;
 import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -39,15 +46,24 @@ public class AsyncGrpcLookupFunction extends AsyncLookupFunction {
 
   private static final Logger LOG = LogManager.getLogger(GrpcServiceClient.class);
 
+  // TODO: Configurable options??
+  private static final int REQUEST_THREAD_POOL_SIZE = 8;
+  private static final int PUBLISHING_THREAD_POOL_SIZE = 4;
+  private static final UncaughtExceptionHandler LOGGING_EXCEPTION_HANDLER =
+      (t, e) -> LOG.error("Thread:" + t + " exited with Exception.", e);
+
   private final GrpcServiceOptions grpcConfig;
   private final SerializationSchema<RowData> requestSchema;
   private final DeserializationSchema<RowData> responseSchema;
   private final Function<RowData, RowData> requestHandler;
   private final GrpcResponseHandler<RowData, RowData, RowData> responseHandler;
+  private final boolean useDirectExecutor;
 
   private transient GrpcServiceClient grpcClient;
   private transient AtomicInteger grpcCallCounter;
   private transient AtomicInteger grpcErrorCounter;
+  private transient Executor requestExecutor;
+  private transient Executor publishingExecutor;
 
   public AsyncGrpcLookupFunction(
       GrpcServiceOptions grpcConfig,
@@ -55,11 +71,22 @@ public class AsyncGrpcLookupFunction extends AsyncLookupFunction {
       GrpcResponseHandler<RowData, RowData, RowData> responseHandler,
       SerializationSchema<RowData> requestSchema,
       DeserializationSchema<RowData> responseSchema) {
+    this(grpcConfig, requestHandler, responseHandler, requestSchema, responseSchema, false);
+  }
+
+  protected AsyncGrpcLookupFunction(
+      GrpcServiceOptions grpcConfig,
+      Function<RowData, RowData> requestHandler,
+      GrpcResponseHandler<RowData, RowData, RowData> responseHandler,
+      SerializationSchema<RowData> requestSchema,
+      DeserializationSchema<RowData> responseSchema,
+      boolean useDirectExecutor) {
     this.grpcConfig = grpcConfig;
     this.requestSchema = requestSchema;
     this.responseSchema = responseSchema;
     this.requestHandler = requestHandler;
     this.responseHandler = responseHandler;
+    this.useDirectExecutor = useDirectExecutor;
   }
 
   @Override
@@ -79,6 +106,21 @@ public class AsyncGrpcLookupFunction extends AsyncLookupFunction {
     context
         .getMetricGroup()
         .gauge("grpc-table-lookup-call-error", () -> grpcErrorCounter.intValue());
+
+    if (useDirectExecutor) {
+      this.requestExecutor = MoreExecutors.directExecutor();
+      this.publishingExecutor = MoreExecutors.directExecutor();
+    } else {
+      this.requestExecutor =
+          Executors.newFixedThreadPool(
+              REQUEST_THREAD_POOL_SIZE,
+              new ExecutorThreadFactory("grpc-async-lookup-worker", LOGGING_EXCEPTION_HANDLER));
+
+      this.publishingExecutor =
+          Executors.newFixedThreadPool(
+              PUBLISHING_THREAD_POOL_SIZE,
+              new ExecutorThreadFactory("grpc-async-publishing-worker", LOGGING_EXCEPTION_HANDLER));
+    }
   }
 
   @Override
@@ -94,27 +136,57 @@ public class AsyncGrpcLookupFunction extends AsyncLookupFunction {
     // Trim request: Metadata filters can show up in request row
     final RowData keyRow = this.requestHandler.apply(req);
 
-    final var grpcCall = this.grpcClient.asyncCall(keyRow);
+    final var grpcCall = this.grpcClient.asyncCall(keyRow, this.requestExecutor);
 
-    return grpcCall.handle(
-        (r, err) -> {
-          if (err != null) {
-            this.grpcErrorCounter.incrementAndGet();
+    final var transformedResult =
+        Futures.transform(
+            grpcCall,
+            r -> {
+              LOG.debug("Handling response: request[{}] response[{}] error[{}]", keyRow, r, null);
+              final var result = this.responseHandler.handle(keyRow, r, null);
+              LOG.debug("Returning response row: {}", result);
+              return List.of(result);
+            },
+            this.publishingExecutor);
+
+    final var resultFut =
+        Futures.catching(
+            transformedResult,
+            Exception.class,
+            err -> {
+              this.grpcErrorCounter.incrementAndGet();
+
+              final var statusErr = findStatusError(err);
+
+              // Propagate any non-status exceptions
+              if (statusErr.isEmpty()) {
+                LOG.error("Found unexpected result error", err);
+                throw new CompletionException(err);
+              }
+
+              LOG.debug(
+                  "Handling response: request[{}] response[{}] error[{}]", keyRow, null, statusErr);
+              final var result = this.responseHandler.handle(keyRow, null, statusErr.orElse(null));
+              LOG.debug("Returning response row: {}", result);
+              return List.of(result);
+            },
+            this.publishingExecutor);
+
+    // Transform to CompletableFuture
+    final var fut = new CompletableFuture<Collection<RowData>>();
+    Futures.addCallback(
+        resultFut,
+        new FutureCallback<>() {
+          public void onFailure(Throwable throwable) {
+            fut.completeExceptionally(throwable);
           }
 
-          final var statusErr = findStatusError(err);
-
-          // Propagate any non-status exceptions
-          if (err != null && statusErr.isEmpty()) {
-            LOG.error("Found unexpected result error", err);
-            throw new CompletionException(err);
+          public void onSuccess(List<RowData> t) {
+            fut.complete(t);
           }
-
-          LOG.debug("Handling response: request[{}] response[{}] error[{}]", keyRow, r, statusErr);
-          final var result = this.responseHandler.handle(keyRow, r, statusErr.orElse(null));
-          LOG.debug("Returning response row: {}", result);
-          return List.of(result);
-        });
+        },
+        this.publishingExecutor);
+    return fut;
   }
 
   private static Optional<StatusRuntimeException> findStatusError(Throwable err) {

--- a/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/GrpcLookupFunction.java
+++ b/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/GrpcLookupFunction.java
@@ -17,6 +17,10 @@ package org.apache.flink.connector.grpc;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.function.Function;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.connector.grpc.handler.GrpcResponseHandler;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.LookupFunction;
@@ -26,7 +30,18 @@ public class GrpcLookupFunction extends LookupFunction {
 
   private final AsyncGrpcLookupFunction delegate;
 
-  public GrpcLookupFunction(AsyncGrpcLookupFunction delegate) {
+  public GrpcLookupFunction(
+      GrpcServiceOptions grpcConfig,
+      Function<RowData, RowData> requestHandler,
+      GrpcResponseHandler<RowData, RowData, RowData> responseHandler,
+      SerializationSchema<RowData> requestSchema,
+      DeserializationSchema<RowData> responseSchema) {
+    this(
+        new AsyncGrpcLookupFunction(
+            grpcConfig, requestHandler, responseHandler, requestSchema, responseSchema, true));
+  }
+
+  private GrpcLookupFunction(AsyncGrpcLookupFunction delegate) {
     this.delegate = delegate;
   }
 

--- a/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/GrpcLookupTableSource.java
+++ b/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/GrpcLookupTableSource.java
@@ -145,22 +145,27 @@ class GrpcLookupTableSource implements LookupTableSource, SupportsReadingMetadat
               }
             };
 
-    final var asyncLookupFunc =
-        new AsyncGrpcLookupFunction(
-            this.grpcConfig,
-            requestHandler,
-            responseHandler,
-            requestSchemaEncoder,
-            responseSchemaDecoder);
-
     if (async) {
+      final var asyncLookupFunc =
+          new AsyncGrpcLookupFunction(
+              this.grpcConfig,
+              requestHandler,
+              responseHandler,
+              requestSchemaEncoder,
+              responseSchemaDecoder);
       if (cache != null) {
         return PartialCachingAsyncLookupProvider.of(asyncLookupFunc, cache);
       } else {
         return AsyncLookupFunctionProvider.of(asyncLookupFunc);
       }
     } else {
-      final var lookupFunc = new GrpcLookupFunction(asyncLookupFunc);
+      final var lookupFunc =
+          new GrpcLookupFunction(
+              this.grpcConfig,
+              requestHandler,
+              responseHandler,
+              requestSchemaEncoder,
+              responseSchemaDecoder);
       if (cache != null) {
         return PartialCachingLookupProvider.of(lookupFunc, cache);
       } else {

--- a/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/service/GrpcServiceClient.java
+++ b/flink-connector-grpc/src/main/java/org/apache/flink/connector/grpc/service/GrpcServiceClient.java
@@ -15,13 +15,15 @@
 //
 package org.apache.flink.connector.grpc.service;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.connector.grpc.GrpcServiceOptions;
@@ -29,7 +31,7 @@ import org.apache.flink.table.data.RowData;
 
 public interface GrpcServiceClient extends Closeable {
 
-  CompletableFuture<RowData> asyncCall(RowData req);
+  ListenableFuture<RowData> asyncCall(RowData req, @Nullable Executor executor);
 
   static final SharedResourceHolder<SharedClientKey, GrpcServiceClient> SHARED_CLIENTS =
       new SharedResourceHolder<>(


### PR DESCRIPTION
Changing the async implementation to use internal thread pools for the GRPC requests and response processing.

Threads are named as 'grpc-async-lookup-worker' and 'grpc-async-publishing-worker'.